### PR TITLE
Capacity of cloned ArrayList

### DIFF
--- a/src/main/java/com/rits/cloning/FastClonerArrayList.java
+++ b/src/main/java/com/rits/cloning/FastClonerArrayList.java
@@ -13,11 +13,11 @@ public class FastClonerArrayList implements IFastCloner
 	@SuppressWarnings({ "unchecked", "rawtypes" })
     public Object clone(final Object t, final IDeepCloner cloner, final Map<Object, Object> clones) {
 		final ArrayList al = (ArrayList) t;
-		final ArrayList l = new ArrayList();
+		final ArrayList l = new ArrayList(al.size());
 		for (final Object o : al)
 		{
-            final Object cloneInternal = cloner.deepClone(o, clones);
-            l.add(cloneInternal);
+        		final Object cloneInternal = cloner.deepClone(o, clones);
+        		l.add(cloneInternal);
 		}
 		return l;
 	}


### PR DESCRIPTION
Let the cloned ArrayList have the same capacity of the original array list. Ensures that the cloned object is a true clone with respect to the internal data structures behind ArrayList as well.