### PR TITLE
Simplifications and Optimizations

### DIFF
--- a/src/main/java/com/rits/cloning/Cloner.java
+++ b/src/main/java/com/rits/cloning/Cloner.java
@@ -441,13 +441,8 @@ public class Cloner {
 		for (final Field field : fields) {
 			final int modifiers = field.getModifiers();
 			if (!Modifier.isStatic(modifiers)) {
-				if (nullTransient && Modifier.isTransient(modifiers)) {
+				if ( ! (nullTransient && Modifier.isTransient(modifiers)) ) {
 					// request by Jonathan : transient fields can be null-ed
-					final Class<?> type = field.getType();
-					if (!type.isPrimitive()) {
-						field.set(newInstance, null);
-					}
-				} else {
 					final Object fieldObject = field.get(o);
 					final boolean shouldClone = (cloneSynthetics || !field.isSynthetic()) && (cloneAnonymousParent || !isAnonymousParent(field));
 					final Object fieldObjectClone = clones != null ? (shouldClone ? cloneInternal(fieldObject, clones) : fieldObject) : fieldObject;

--- a/src/main/java/com/rits/cloning/Cloner.java
+++ b/src/main/java/com/rits/cloning/Cloner.java
@@ -464,10 +464,14 @@ public class Cloner {
 		if (clones != null) {
 			clones.put(o, newInstance);
 		}
-		for (int i = 0; i < length; i++) {
-			final Object v = Array.get(o, i);
-			final Object clone = clones != null ? cloneInternal(v, clones) : v;
-			Array.set(newInstance, i, clone);
+		if(clz.getComponentType().isPrimitive() || isImmutable(clz.getComponentType())) {
+			System.arraycopy(o, 0, newInstance, 0, length);
+		} else {
+			for (int i = 0; i < length; i++) {
+				final Object v = Array.get(o, i);
+				final Object clone = clones != null ? cloneInternal(v, clones) : v;
+				Array.set(newInstance, i, clone);
+			}
 		}
 		return newInstance;
 	}

--- a/src/main/java/com/rits/cloning/Cloner.java
+++ b/src/main/java/com/rits/cloning/Cloner.java
@@ -449,7 +449,7 @@ public class Cloner {
 					}
 				} else {
 					final Object fieldObject = field.get(o);
-					final boolean shouldClone = (cloneSynthetics || (!cloneSynthetics && !field.isSynthetic())) && (cloneAnonymousParent || ((!cloneAnonymousParent && !isAnonymousParent(field))));
+					final boolean shouldClone = (cloneSynthetics || !field.isSynthetic()) && (cloneAnonymousParent || !isAnonymousParent(field));
 					final Object fieldObjectClone = clones != null ? (shouldClone ? cloneInternal(fieldObject, clones) : fieldObject) : fieldObject;
 					field.set(newInstance, fieldObjectClone);
 					if (dumpCloned != null && fieldObjectClone != fieldObject) {


### PR DESCRIPTION
I was reading your code and would like to propose three improvements:
1) Using System.arraycopy for Arrays of primitives or immutables
2) Elimination of explicitly assigning null to transient fields after initialization (as these fields are
    null anyways)
3) simplification of a boolean expression.

I ran all the tests and they passed.
