### PR TITLE
update search.maven.org url

### DIFF
--- a/wiki/Maven_Dependency.md
+++ b/wiki/Maven_Dependency.md
@@ -1,1 +1,1 @@
-Please see [here](http://search.maven.org/#search|gav|1|g%3A%22uk.com.robust-it%22%20AND%20a%3A%22cloning%22).
+Please see [here](https://search.maven.org/search?q=g:%22uk.com.robust-it%22%20AND%20a:%22cloning%22).


### PR DESCRIPTION
search.maven.org changed quite a bit recently, and the search URL syntax changed too. This updates the wiki page to use the new syntax.