### PR TITLE
suppress warnings where we know the cast is correct

### DIFF
--- a/src/main/java/com/rits/cloning/Cloner.java
+++ b/src/main/java/com/rits/cloning/Cloner.java
@@ -1,7 +1,6 @@
 package com.rits.cloning;
 
 import org.objenesis.instantiator.ObjectInstantiator;
-import sun.reflect.ReflectionFactory;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
@@ -481,7 +480,7 @@ public class Cloner {
 				dumpCloned.startCloning(o.getClass());
 			}
 			int length = Array.getLength(o);
-			T newInstance = (T) Array.newInstance(componentType, length);
+			@SuppressWarnings("unchecked") T newInstance = (T) Array.newInstance(componentType, length);
 			if (clones != null) {
 				clones.put(o, newInstance);
 			}
@@ -512,7 +511,7 @@ public class Cloner {
 		}
 
 		public <T> T deepClone(T o, Map<Object, Object> clones) {
-			T clone = (T) fastCloner.clone(o, cloneInternal, clones);
+			@SuppressWarnings("unchecked") T clone = (T) fastCloner.clone(o, cloneInternal, clones);
 			if (clones != null) clones.put(o, clone);
 			return clone;
 		}
@@ -592,7 +591,7 @@ public class Cloner {
 				if (dumpCloned != null) {
 					dumpCloned.startCloning(o.getClass());
 				}
-				T newInstance = (T) instantiator.newInstance();
+				@SuppressWarnings("unchecked") T newInstance = (T) instantiator.newInstance();
 				if (clones != null) {
 					clones.put(o, newInstance);
 					for (int i = 0; i < numFields; i++) {

--- a/src/main/java/com/rits/cloning/CloningStrategyFactory.java
+++ b/src/main/java/com/rits/cloning/CloningStrategyFactory.java
@@ -1,9 +1,10 @@
 package com.rits.cloning;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 
 public class CloningStrategyFactory {
-	public static ICloningStrategy annotatedField(final Class annotationClass, final ICloningStrategy.Strategy strategy) {
+	public static ICloningStrategy annotatedField(final Class<? extends Annotation> annotationClass, final ICloningStrategy.Strategy strategy) {
 		return new ICloningStrategy() {
 			public Strategy strategyFor(Object toBeCloned, Field field) {
 				if (toBeCloned == null) return Strategy.IGNORE;

--- a/src/main/java/com/rits/cloning/FastClonerTreeSet.java
+++ b/src/main/java/com/rits/cloning/FastClonerTreeSet.java
@@ -23,6 +23,7 @@ public class FastClonerTreeSet implements IFastCloner {
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	public Object clone(Object t, IDeepCloner cloner, Map<Object, Object> clones) {
 		TreeSet treeSet = (TreeSet) t;
 		TreeSet result = null;

--- a/src/main/java/com/rits/cloning/IDumpCloned.java
+++ b/src/main/java/com/rits/cloning/IDumpCloned.java
@@ -3,7 +3,7 @@ package com.rits.cloning;
 import java.lang.reflect.Field;
 
 /**
- * @author: kostas.kougios
+ * @author kostas.kougios
  * Date: 06/08/13
  */
 public interface IDumpCloned


### PR DESCRIPTION
There are several places in the code where we instantiate objects where we can't prove to the compiler they are correct casts but they will be correct at runtime. This should remove all the warnings that Java 8 produces during compilation. I don't think that this warrants another release.