### PR TITLE
Added FastClonerEnumMap and FastClonerLinkedHashSet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<packaging>bundle</packaging>
 	<version>1.10.1</version>
 	<name>cloning</name>
-	<url>https://code.google.com/p/cloning/</url>
+	<url>https://github.com/kostaskougios/cloning/</url>
 	<description><![CDATA[
                 The cloning library is a small, open source (Apache
                 licensed) Java library which deep-clones objects. The

--- a/src/main/java/com/rits/cloning/Cloner.java
+++ b/src/main/java/com/rits/cloning/Cloner.java
@@ -104,6 +104,7 @@ public class Cloner {
 		fastCloners.put(LinkedHashMap.class, new FastClonerLinkedHashMap());
 		fastCloners.put(ConcurrentHashMap.class, new FastClonerConcurrentHashMap());
 		fastCloners.put(ConcurrentLinkedQueue.class, new FastClonerConcurrentLinkedQueue());
+		fastCloners.put(EnumMap.class, new FastClonerEnumMap());
 
 		// register private classes
 		FastClonerArrayListSubList subListCloner = new FastClonerArrayListSubList();

--- a/src/main/java/com/rits/cloning/Cloner.java
+++ b/src/main/java/com/rits/cloning/Cloner.java
@@ -105,6 +105,7 @@ public class Cloner {
 		fastCloners.put(ConcurrentHashMap.class, new FastClonerConcurrentHashMap());
 		fastCloners.put(ConcurrentLinkedQueue.class, new FastClonerConcurrentLinkedQueue());
 		fastCloners.put(EnumMap.class, new FastClonerEnumMap());
+		fastCloners.put(LinkedHashSet.class, new FastClonerLinkedHashSet());
 
 		// register private classes
 		FastClonerArrayListSubList subListCloner = new FastClonerArrayListSubList();

--- a/src/main/java/com/rits/cloning/FastClonerEnumMap.java
+++ b/src/main/java/com/rits/cloning/FastClonerEnumMap.java
@@ -1,0 +1,30 @@
+package com.rits.cloning;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Fast Cloner for EnumMaps
+ * 
+ * @author Tobias Weimer
+ */
+public class FastClonerEnumMap implements IFastCloner
+{
+	@Override
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public Object clone(final Object toBeCloned, final IDeepCloner cloner, final Map<Object, Object> clones) {
+		final EnumMap<? extends Enum<?>, ?> m = (EnumMap) toBeCloned;
+		
+		// make a shallow copy of the original EnumMap
+		// since there is no no-arg-constructor
+		final EnumMap result = new EnumMap(m);
+		
+		// Now clone the values
+		for (final Map.Entry<? extends Enum<?>, ?> e : m.entrySet()) {
+			// No need to clone the key, since it is an Enum
+			// However, the value MUST be cloned
+			result.put(e.getKey(), cloner.deepClone(e.getValue(), clones));
+		}
+		return result;
+	}
+}

--- a/src/main/java/com/rits/cloning/FastClonerLinkedHashSet.java
+++ b/src/main/java/com/rits/cloning/FastClonerLinkedHashSet.java
@@ -1,0 +1,24 @@
+package com.rits.cloning;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+/**
+ * Fast Cloner for LinkedHashSet
+ * 
+ * @author Tobias Weimer
+ */
+public class FastClonerLinkedHashSet implements IFastCloner
+{
+	@Override
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+    public Object clone(final Object t, final IDeepCloner cloner, final Map<Object, Object> clones) {
+		final LinkedHashSet<?> al = (LinkedHashSet) t;
+		final LinkedHashSet l = new LinkedHashSet();
+		for (final Object o : al)
+		{
+			l.add(cloner.deepClone(o, clones));
+		}
+		return l;
+	}
+}

--- a/src/test/java/com/rits/tests/cloning/TestCloner.java
+++ b/src/test/java/com/rits/tests/cloning/TestCloner.java
@@ -791,22 +791,29 @@ public class TestCloner extends TestCase {
 		assertNotSame(list.peek(), cloned.peek());
 	}
 
+	/**
+	 * Test case with EnumMap where one Enum is mapped onto null
+	 */
 	public void testEnumMapWithNullValue() {
 		EnumMap<TestEnum, String> originalMap = new EnumMap<>(TestEnum.class);
 		originalMap.put(TestEnum.A, null);
 
 		EnumMap<TestEnum, String> clonedMap = cloner.deepClone(originalMap);
-		assertTrue("Cloned LinkedHashSet not instanceof EnumMap", clonedMap instanceof EnumMap);
+		assertNotSame("Cloned EnumMap same as original EnumMap", originalMap, clonedMap);
 		assertEquals("Cloned Map not of expected size", 1, clonedMap.size());
-		assertNull("Expected value is null", clonedMap.get(TestEnum.A));
+		assertNull("Expected value is null (contains key A)", clonedMap.get(TestEnum.A));
+		assertNull("Expected value is null (doesn't contain key B)", clonedMap.get(TestEnum.B));
 		assertTrue("Cloned Map doesn't contain key A", clonedMap.containsKey(TestEnum.A));
 		assertEquals("Cloned EnumMap not equal to original EnumMap", originalMap, clonedMap);
 	}
 
+	/**
+	 * Test case for an empty EnumMap
+	 */
 	public void testEmptyEnumMap() {
 		EnumMap<TestEnum, String> originalMap = new EnumMap<>(TestEnum.class);
 		EnumMap<TestEnum, String> clonedMap = cloner.deepClone(originalMap);
-		assertTrue("Cloned LinkedHashSet not instanceof EnumMap", clonedMap instanceof EnumMap);
+		assertNotSame("Cloned EnumMap same as original EnumMap", originalMap, clonedMap);
 		assertEquals("Cloned Map is not empty", 0, clonedMap.size());
 		assertTrue("Cloned Map is not empty", clonedMap.isEmpty());
 		assertEquals("Cloned EnumMap not equal to original EnumMap", originalMap, clonedMap);
@@ -814,15 +821,41 @@ public class TestCloner extends TestCase {
 	
 
 
+	/**
+	 * Test case for non empty EnumMap
+	 */
 	public void testEnumMapWithNonNullValue() {
 		EnumMap<TestEnum, String> originalMap = new EnumMap<>(TestEnum.class);
 		originalMap.put(TestEnum.A, "Hello");
 		EnumMap<TestEnum, String> clonedMap = cloner.deepClone(originalMap);
-		assertTrue("Cloned LinkedHashSet not instanceof EnumMap", clonedMap instanceof EnumMap);
+		assertNotSame("Cloned EnumMap same as original EnumMap", originalMap, clonedMap);
 		assertEquals("Cloned EnumMap not equal to original EnumMap", originalMap, clonedMap);
 		assertEquals("Cloned EnumMap value not equal to original EnumMap", originalMap.get(TestEnum.A), clonedMap.get(TestEnum.A));
 	}
 	
+	/**
+	 * Test case for EnumMap with non-null mutable value
+	 * to see if it is deep cloned
+	 */
+	public void testEnumMapWithNonNullMutableValue() {
+		EnumMap<TestEnum, DC> originalMap = new EnumMap<>(TestEnum.class);
+		DC dc = new DC(5);
+		originalMap.put(TestEnum.A, dc);
+		EnumMap<TestEnum, DC> clonedMap = cloner.deepClone(originalMap);
+		assertNotSame("Cloned EnumMap same as original EnumMap", originalMap, clonedMap);
+		assertEquals("Cloned EnumMap not equal to original EnumMap", originalMap, clonedMap);
+		
+		DC dc2 = clonedMap.get(TestEnum.A);
+		// Assert references are different
+		assertNotSame("value not cloned", dc, dc2);
+		// Assert both objects are equal
+		assertEquals("Cloned value not equal to original object", dc, dc2);
+		
+	}
+	
+	/**
+	 * Test case for cloning LinkedHashSet
+	 */
 	public void testLinkedHashSetToArray() {
 		Set<Object> set = new LinkedHashSet<>();
 		set.add(new Object());
@@ -837,13 +870,55 @@ public class TestCloner extends TestCase {
 		assertTrue("First element not removed from LinkedHashSet", clonedSet.remove(first));
 	}
 	
+	/**
+	 * Another test case for LinkedHashSet
+	 */
 	public void testLinkedHashSetEquals() {
-		Set<Object> set = new LinkedHashSet<>();
-		set.add("Test 1");
-		set.add("Test 2");
+		LinkedHashSet<String> originalSet = new LinkedHashSet<>();
+		originalSet.add("Test 1");
+		originalSet.add("Test 2");
 
-		Set<Object> clonedSet = cloner.deepClone(set);
-		assertTrue("Cloned LinkedHashSet not instanceof LinkedHashSet", clonedSet instanceof LinkedHashSet);
-		assertEquals("Cloned LinkedHashSet not equal to original one", set, clonedSet);
+		LinkedHashSet<String> clonedSet = cloner.deepClone(originalSet);
+		assertNotSame("Cloned LinkedHashSet same as original one", originalSet, clonedSet);
+		assertEquals("Cloned LinkedHashSet not equal to original one", originalSet, clonedSet);
+	}
+	
+
+	/**
+	 * Test if insertion order of LinkedhashSet is the same
+	 */
+	public void testLinkedHashSetInserationOrder() {
+		LinkedHashSet<Integer> originalSet = new LinkedHashSet<>();
+		for (int i = 1000; i >= 1; i--) {
+			originalSet.add(i);
+		}
+		
+		LinkedHashSet<Integer> clonedSet = cloner.deepClone(originalSet);
+		assertEquals("Cloned LinkedHashSet not equal to original one", originalSet,  clonedSet);
+		int i = 1000;
+		for (Integer act : clonedSet) {
+			assertEquals("LinkedHashSet iteration order not preserved", i--, act.intValue());
+		}
+	}
+	
+	/**
+	 * Tests if LinkedHashSet with mutable value is deep cloned
+	 */
+	public void testLinkedHashSetWithMitableValue() {
+		LinkedHashSet<DC> originalSet = new LinkedHashSet<>();
+		DC dc = new DC(1000);
+		originalSet.add(dc);
+		
+		LinkedHashSet<DC> clonedSet = cloner.deepClone(originalSet);
+		assertEquals("Size of cloned LinkedHashSet is wrong", 1, clonedSet.size());
+		assertNotSame("Cloned LinkedHashSet same as original one", originalSet,  clonedSet);
+		assertEquals("Cloned LinkedHashSet not equal to original one", originalSet,  clonedSet);
+		DC dc2 = clonedSet.iterator().next();
+		// Assert references are different
+		assertNotSame("value not cloned", dc, dc2);
+		// Assert both objects are equal
+		assertEquals("Cloned value not equal to original object", dc, dc2);
+		
 	}
 }
+

--- a/src/test/java/com/rits/tests/cloning/TestCloner.java
+++ b/src/test/java/com/rits/tests/cloning/TestCloner.java
@@ -796,6 +796,7 @@ public class TestCloner extends TestCase {
 		originalMap.put(TestEnum.A, null);
 
 		EnumMap<TestEnum, String> clonedMap = cloner.deepClone(originalMap);
+		assertTrue("Cloned LinkedHashSet not instanceof EnumMap", clonedMap instanceof EnumMap);
 		assertEquals("Cloned Map not of expected size", 1, clonedMap.size());
 		assertNull("Expected value is null", clonedMap.get(TestEnum.A));
 		assertTrue("Cloned Map doesn't contain key A", clonedMap.containsKey(TestEnum.A));
@@ -805,6 +806,7 @@ public class TestCloner extends TestCase {
 	public void testEmptyEnumMap() {
 		EnumMap<TestEnum, String> originalMap = new EnumMap<>(TestEnum.class);
 		EnumMap<TestEnum, String> clonedMap = cloner.deepClone(originalMap);
+		assertTrue("Cloned LinkedHashSet not instanceof EnumMap", clonedMap instanceof EnumMap);
 		assertEquals("Cloned Map is not empty", 0, clonedMap.size());
 		assertTrue("Cloned Map is not empty", clonedMap.isEmpty());
 		assertEquals("Cloned EnumMap not equal to original EnumMap", originalMap, clonedMap);
@@ -816,7 +818,32 @@ public class TestCloner extends TestCase {
 		EnumMap<TestEnum, String> originalMap = new EnumMap<>(TestEnum.class);
 		originalMap.put(TestEnum.A, "Hello");
 		EnumMap<TestEnum, String> clonedMap = cloner.deepClone(originalMap);
+		assertTrue("Cloned LinkedHashSet not instanceof EnumMap", clonedMap instanceof EnumMap);
 		assertEquals("Cloned EnumMap not equal to original EnumMap", originalMap, clonedMap);
 		assertEquals("Cloned EnumMap value not equal to original EnumMap", originalMap.get(TestEnum.A), clonedMap.get(TestEnum.A));
+	}
+	
+	public void testLinkedHashSetToArray() {
+		Set<Object> set = new LinkedHashSet<>();
+		set.add(new Object());
+		set.add(new Object());
+
+		Set<Object> clonedSet = cloner.deepClone(set);
+		assertTrue("Cloned LinkedHashSet not instanceof LinkedHashSet", clonedSet instanceof LinkedHashSet);
+		
+		
+		Object first = clonedSet.toArray()[0];
+		assertTrue("First element not contained in cloned LinkedHashSet", clonedSet.contains(first));
+		assertTrue("First element not removed from LinkedHashSet", clonedSet.remove(first));
+	}
+	
+	public void testLinkedHashSetEquals() {
+		Set<Object> set = new LinkedHashSet<>();
+		set.add("Test 1");
+		set.add("Test 2");
+
+		Set<Object> clonedSet = cloner.deepClone(set);
+		assertTrue("Cloned LinkedHashSet not instanceof LinkedHashSet", clonedSet instanceof LinkedHashSet);
+		assertEquals("Cloned LinkedHashSet not equal to original one", set, clonedSet);
 	}
 }

--- a/src/test/java/com/rits/tests/cloning/TestCloner.java
+++ b/src/test/java/com/rits/tests/cloning/TestCloner.java
@@ -790,4 +790,33 @@ public class TestCloner extends TestCase {
 		assertNotSame(list, cloned);
 		assertNotSame(list.peek(), cloned.peek());
 	}
+
+	public void testEnumMapWithNullValue() {
+		EnumMap<TestEnum, String> originalMap = new EnumMap<>(TestEnum.class);
+		originalMap.put(TestEnum.A, null);
+
+		EnumMap<TestEnum, String> clonedMap = cloner.deepClone(originalMap);
+		assertEquals("Cloned Map not of expected size", 1, clonedMap.size());
+		assertNull("Expected value is null", clonedMap.get(TestEnum.A));
+		assertTrue("Cloned Map doesn't contain key A", clonedMap.containsKey(TestEnum.A));
+		assertEquals("Cloned EnumMap not equal to original EnumMap", originalMap, clonedMap);
+	}
+
+	public void testEmptyEnumMap() {
+		EnumMap<TestEnum, String> originalMap = new EnumMap<>(TestEnum.class);
+		EnumMap<TestEnum, String> clonedMap = cloner.deepClone(originalMap);
+		assertEquals("Cloned Map is not empty", 0, clonedMap.size());
+		assertTrue("Cloned Map is not empty", clonedMap.isEmpty());
+		assertEquals("Cloned EnumMap not equal to original EnumMap", originalMap, clonedMap);
+	}
+	
+
+
+	public void testEnumMapWithNonNullValue() {
+		EnumMap<TestEnum, String> originalMap = new EnumMap<>(TestEnum.class);
+		originalMap.put(TestEnum.A, "Hello");
+		EnumMap<TestEnum, String> clonedMap = cloner.deepClone(originalMap);
+		assertEquals("Cloned EnumMap not equal to original EnumMap", originalMap, clonedMap);
+		assertEquals("Cloned EnumMap value not equal to original EnumMap", originalMap.get(TestEnum.A), clonedMap.get(TestEnum.A));
+	}
 }


### PR DESCRIPTION
Hi Konstantinos,
I am using your Cloning library, and I found a bug with cloning of EnumMaps.
If any key of an EnumMap is being mapped to `null`, the cloned EnumMap will *not* map it to `null`, but to a random instance of `Object`.

I tracked down that problem and the cause of the problem is that `EnumMap` is using a marker object `java.util.EnumMap.NULL` to distinguish enums mapped to `null` from objects not contained in the map at all. `java.util.EnumMap.NULL` is used in `maskNull` and `unmaskNull` by reference comparision, so after `NULL` is cloned, the reference comparision goes wrong.

You are able to reproduce that problem with the JUnit test included in my Pull Request.

In order to solve the problem, I have introduced `FastClonerEnumMap`. It is basically taken from `FastClonerHashMap`, with some modification for `EnumMap`. It is registered in `com.rits.cloning.Cloner.registerFastCloners()`.

After that, the JUnit tests I added are working fine. Feel free to add additional ones.

I also added FastClonerLinkedhashSet, which will fix #46 (JUnit tests are included too).

I also updated pom.xml (fixes #66)

I hope you will merge this PR. If you have any objections, please let me know!
