### PR TITLE
FastClonerTreeSet shall not use reflection

### DIFF
--- a/src/main/java/com/rits/cloning/FastClonerTreeSet.java
+++ b/src/main/java/com/rits/cloning/FastClonerTreeSet.java
@@ -2,36 +2,15 @@ package com.rits.cloning;
 
 import com.rits.cloning.IFastCloner;
 
-import java.lang.reflect.Field;
-import java.util.Comparator;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.TreeSet;
 
 public class FastClonerTreeSet implements IFastCloner {
-	private static final Field m;
-	private static final Field comparator;
-
-	static {
-		try {
-			m = TreeSet.class.getDeclaredField("m");
-			m.setAccessible(true);
-			comparator = TreeMap.class.getDeclaredField("comparator");
-			comparator.setAccessible(true);
-		} catch (NoSuchFieldException e) {
-			throw new CloningException(e);
-		}
-	}
-
+	@Override
 	@SuppressWarnings("unchecked")
 	public Object clone(Object t, IDeepCloner cloner, Map<Object, Object> clones) {
-		TreeSet treeSet = (TreeSet) t;
-		TreeSet result = null;
-		try {
-			result = new TreeSet((Comparator) comparator.get(m.get(t)));
-		} catch (IllegalAccessException e) {
-			throw new CloningException("Failed to get the comparator from a tree set", e);
-		}
+		TreeSet<?> treeSet = (TreeSet<?>) t;
+		TreeSet result = new TreeSet(treeSet.comparator());
 		for (Object o : treeSet) {
 			result.add(cloner.deepClone(o, clones));
 		}


### PR DESCRIPTION
This pull request fixes #90.

This basically removes the unnecessary reflection from `FastClonerTreeSet`, in the same way as `FastClonerTreeMap`. I see no reason to use reflection in that place, the comparator is accessible and `FastClonerTreeMap` does it in the same way. That code was introduced in #85.

This will also remove that warning at startup:

> WARNING: Illegal reflective access by com.rits.cloning.FastClonerTreeSet (file:/home/xxxx/git/cloning/target/classes/) to field java.util.TreeSet.m

PS: If you merge it, please push a new version at maven central, thanks!