### PR TITLE
Fix for a ClassCastException

### DIFF
--- a/src/main/java/com/rits/cloning/Cloner.java
+++ b/src/main/java/com/rits/cloning/Cloner.java
@@ -221,7 +221,7 @@ public class Cloner {
 	 * @param set a set of classes which will be scanned for static fields
 	 */
 	public void setExtraStaticFields(final Set<Class<?>> set) {
-		registerStaticFields((Class<?>[]) set.toArray());
+		registerStaticFields(set.toArray(new Class<?>[0]));
 	}
 
 	/**


### PR DESCRIPTION
This commit fixes a `ClassCastException` in that method.

See the contract of Collection.toArray(): "The returned array's **runtime component type** is Object." That is because of the type erasure.

Thus casting `Object[]` to `Class[]` will result in `ClassCastException.`


> java.lang.ClassCastException: class [Ljava.lang.Object; cannot be cast to class [Ljava.lang.Class; ([Ljava.lang.Object; and [Ljava.lang.Class; are in module java.base of loader 'bootstrap')
> 	at com.rits.cloning.Cloner.setExtraStaticFields(Cloner.java:224)