### PR TITLE
Fix for #105

### DIFF
--- a/src/main/java/com/rits/cloning/Cloner.java
+++ b/src/main/java/com/rits/cloning/Cloner.java
@@ -578,15 +578,17 @@ public class Cloner {
 			do {
 				Field[] fs = sc.getDeclaredFields();
 				for (final Field f : fs) {
-					if (!f.isAccessible()) {
-						f.setAccessible(true);
-					}
 					int modifiers = f.getModifiers();
 					if (!Modifier.isStatic(modifiers)) {
 						if (!(nullTransient && Modifier.isTransient(modifiers)) && !isFieldNullInsteadBecauseOfAnnotation(f)) {
 							l.add(f);
 							boolean shouldClone = (cloneSynthetics || !f.isSynthetic()) && (cloneAnonymousParent || !isAnonymousParent(f));
 							shouldCloneList.add(shouldClone);
+							if (shouldClone) {
+								if (!f.isAccessible()) {
+									f.setAccessible(true);
+								}
+							}
 						}
 					}
 				}

--- a/src/test/java/com/rits/tests/cloning/TestCloner.java
+++ b/src/test/java/com/rits/tests/cloning/TestCloner.java
@@ -908,5 +908,11 @@ public class TestCloner extends TestCase {
         assertEquals("Cloned value not equal to original object", dc, dc2);
 
     }
+    
+    public void testStaticTransientMembers() {
+       class StaticTransient extends ArrayList<String> {};
+        
+       cloner.deepClone(new StaticTransient());
+    }
 }
 


### PR DESCRIPTION
Okay, I tested that with the specified fis and test case, as in the commit linked above.

Before the fix, the test failed with:

> testStaticTransientMembers(com.rits.tests.cloning.TestCloner)  Time elapsed: 0.002 sec  <<< ERROR!
> java.lang.reflect.InaccessibleObjectException: Unable to make field private static final long java.util.ArrayList.serialVersionUID accessible: module java.base does not "opens java.util" to unnamed module @23ceabc1
> 	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:357)
> 	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
> 	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:177)
> 	at java.base/java.lang.reflect.Field.setAccessible(Field.java:171)
> 	at com.rits.cloning.Cloner$CloneObjectCloner.<init>(Cloner.java:582)
> 	at com.rits.cloning.Cloner.findDeepCloner(Cloner.java:477)
> 	at com.rits.cloning.Cloner.cloneInternal(Cloner.java:441)
> 	at com.rits.cloning.Cloner.deepClone(Cloner.java:340)
> 	at com.rits.tests.cloning.TestCloner.testStaticTransientMembers(TestCloner.java:915)


After the fix, that Exception is gone, but tjhere is another one:

> testStaticTransientMembers(com.rits.tests.cloning.TestCloner)  Time elapsed: 0.002 sec  <<< ERROR!
> java.lang.reflect.InaccessibleObjectException: Unable to make field transient java.lang.Object[] java.util.ArrayList.elementData accessible: module java.base does not "opens java.util" to unnamed module @23ceabc1
> 	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:357)
> 	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
> 	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:177)
> 	at java.base/java.lang.reflect.Field.setAccessible(Field.java:171)
> 	at com.rits.cloning.Cloner$CloneObjectCloner.<init>(Cloner.java:589)
> 	at com.rits.cloning.Cloner.findDeepCloner(Cloner.java:477)
> 	at com.rits.cloning.Cloner.cloneInternal(Cloner.java:441)
> 	at com.rits.cloning.Cloner.deepClone(Cloner.java:340)
> 	at com.rits.tests.cloning.TestCloner.testStaticTransientMembers(TestCloner.java:915)

That doesn't make it much better, but at least the fix doesn't hurt.

Fixes #105 