### PR TITLE
Fixed tests in Java 16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,11 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.15</version>
+				<version>3.0.0-M5</version>
 				<configuration>
+					<argLine>
+						--illegal-access=permit
+					</argLine>
 					<includes>
 						<include>**/Test*.java</include>
 					</includes>


### PR DESCRIPTION
This commit adds --illegal-access=permit, which is needed in Java 16 and above
Because --illegal-access=deny is the new default.

While this is not required for Java < 16, it doesn't hurt either.