### PR TITLE
fix the issue #103 by create two new FastCloners

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
 		<dependency>
 			<groupId>org.objenesis</groupId>
 			<artifactId>objenesis</artifactId>
-			<version>3.0.1</version>
+			<version>3.2</version>
 		</dependency>
 	</dependencies>
 	<profiles>

--- a/src/main/java/com/rits/cloning/Cloner.java
+++ b/src/main/java/com/rits/cloning/Cloner.java
@@ -5,6 +5,7 @@ import org.objenesis.instantiator.ObjectInstantiator;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
+
 import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -113,6 +114,10 @@ public class Cloner {
 		registerInaccessibleClassToBeFastCloned("java.util.ArrayList$SubList", subListCloner);
 		registerInaccessibleClassToBeFastCloned("java.util.SubList", subListCloner);
 		registerInaccessibleClassToBeFastCloned("java.util.RandomAccessSubList", subListCloner);
+		FastClonerListOf12 listOf12 = new FastClonerListOf12();
+		registerInaccessibleClassToBeFastCloned("java.util.ImmutableCollections$List12",listOf12);
+		FastClonerSetOf12 setOf12 = new FastClonerSetOf12();
+		registerInaccessibleClassToBeFastCloned("java.util.ImmutableCollections$Set12",setOf12);
 	}
 
 	protected void registerInaccessibleClassToBeFastCloned(String className, IFastCloner fastCloner) {

--- a/src/main/java/com/rits/cloning/FastClonerListOf12.java
+++ b/src/main/java/com/rits/cloning/FastClonerListOf12.java
@@ -8,11 +8,13 @@ public class FastClonerListOf12 implements IFastCloner {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public Object clone(final Object t, final IDeepCloner cloner, final Map<Object, Object> clones) {
         List al = (List) t;
-        if (al.size()==1){
-            return List.of(al.get(0));
-        }else if (al.size()==2){
-            return List.of(al.get(0),al.get(1));
-        }else {
+        if (al.size() == 1) {
+            return List.of(cloner.deepClone(al.get(0), clones));
+        } else if (al.size() == 2) {
+            Object o1 = cloner.deepClone(al.get(0), clones);
+            Object o2 = cloner.deepClone(al.get(1), clones);
+            return List.of(o1, o2);
+        } else {
             return new ArrayList<>();
         }
     }

--- a/src/main/java/com/rits/cloning/FastClonerListOf12.java
+++ b/src/main/java/com/rits/cloning/FastClonerListOf12.java
@@ -1,0 +1,20 @@
+package com.rits.cloning;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class FastClonerListOf12 implements IFastCloner {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public Object clone(final Object t, final IDeepCloner cloner, final Map<Object, Object> clones) {
+        List al = (List) t;
+        if (al.size()==1){
+            return List.of(al.get(0));
+        }else if (al.size()==2){
+            return List.of(al.get(0),al.get(1));
+        }else {
+            return new ArrayList<>();
+        }
+    }
+
+}

--- a/src/main/java/com/rits/cloning/FastClonerSetOf12.java
+++ b/src/main/java/com/rits/cloning/FastClonerSetOf12.java
@@ -2,16 +2,18 @@ package com.rits.cloning;
 
 import java.util.*;
 
-public class FastClonerSetOf12 implements IFastCloner{
+public class FastClonerSetOf12 implements IFastCloner {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public Object clone(final Object t, final IDeepCloner cloner, final Map<Object, Object> clones) {
-        Set set=(Set) t;
-        Object[] a=set.toArray();
-        if (set.size()==1){
-            return Set.of(a[0]);
-        }else if (set.size()==2){
-            return Set.of(a[0],a[1]);
-        }else {
+        Set set = (Set) t;
+        Object[] a = set.toArray();
+        if (set.size() == 1) {
+            return Set.of(cloner.deepClone(a[0], clones));
+        } else if (set.size() == 2) {
+            Object o1 = cloner.deepClone(a[0], clones);
+            Object o2 = cloner.deepClone(a[1], clones);
+            return Set.of(o1, o2);
+        } else {
             return new HashSet<>();
         }
     }

--- a/src/main/java/com/rits/cloning/FastClonerSetOf12.java
+++ b/src/main/java/com/rits/cloning/FastClonerSetOf12.java
@@ -1,0 +1,18 @@
+package com.rits.cloning;
+
+import java.util.*;
+
+public class FastClonerSetOf12 implements IFastCloner{
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public Object clone(final Object t, final IDeepCloner cloner, final Map<Object, Object> clones) {
+        Set set=(Set) t;
+        Object[] a=set.toArray();
+        if (set.size()==1){
+            return Set.of(a[0]);
+        }else if (set.size()==2){
+            return Set.of(a[0],a[1]);
+        }else {
+            return new HashSet<>();
+        }
+    }
+}

--- a/src/test/java/com/rits/tests/cloning/TestCloner.java
+++ b/src/test/java/com/rits/tests/cloning/TestCloner.java
@@ -878,7 +878,7 @@ public class TestCloner extends TestCase {
     /**
      * Test if insertion order of LinkedhashSet is the same
      */
-    public void testLinkedHashSetInserationOrder() {
+    public void testLinkedHashSetIterationOrder() {
         LinkedHashSet<Integer> originalSet = new LinkedHashSet<>();
         for (int i = 1000; i >= 1; i--) {
             originalSet.add(i);

--- a/src/test/java/com/rits/tests/cloning/TestCloner.java
+++ b/src/test/java/com/rits/tests/cloning/TestCloner.java
@@ -10,8 +10,10 @@ import org.junit.Assert;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Function;
 
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -914,6 +916,12 @@ public class TestCloner extends TestCase {
         }
 
         cloner.deepClone(new StaticTransient());
+    }
+
+    public void ignoreTestLambda() {
+        // this fails with "Caused by: java.lang.ClassNotFoundException: com.rits.tests.cloning.TestCloner$$Lambda$54.0x0000000800c24210"
+        Function<ZonedDateTime, Integer> f = ZonedDateTime::getNano;
+        cloner.deepClone(f);
     }
 }
 

--- a/src/test/java/com/rits/tests/cloning/TestCloner.java
+++ b/src/test/java/com/rits/tests/cloning/TestCloner.java
@@ -42,6 +42,14 @@ public class TestCloner extends TestCase {
     static private class MyAX {
     }
 
+    public void testCloneListOf12(){
+        Assert.assertEquals(1, cloner.deepClone(List.of(1)).size());
+    }
+
+    public void testCloneSetOf12(){
+        Assert.assertEquals(1, cloner.deepClone(Set.of(1)).size());
+    }
+
     public void testCalendarTimezone() {
         TimeZone timeZone = TimeZone.getTimeZone("America/Los_Angeles");
         Calendar c = Calendar.getInstance(timeZone);

--- a/src/test/java/com/rits/tests/cloning/TestCloner.java
+++ b/src/test/java/com/rits/tests/cloning/TestCloner.java
@@ -13,6 +13,7 @@ import java.lang.annotation.Target;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import static java.lang.annotation.ElementType.TYPE;
@@ -922,6 +923,17 @@ public class TestCloner extends TestCase {
         // this fails with "Caused by: java.lang.ClassNotFoundException: com.rits.tests.cloning.TestCloner$$Lambda$54.0x0000000800c24210"
         Function<ZonedDateTime, Integer> f = ZonedDateTime::getNano;
         cloner.deepClone(f);
+    }
+
+    private static class ClassWithEnum {
+        TimeUnit timeUnit;
+    }
+
+    public void testClassWithEnum() {
+        ClassWithEnum a = new ClassWithEnum();
+        a.timeUnit = TimeUnit.SECONDS;
+        ClassWithEnum b = cloner.deepClone(a);
+        assertSame(TimeUnit.SECONDS, b.timeUnit);
     }
 }
 

--- a/src/test/java/com/rits/tests/cloning/TestCloner.java
+++ b/src/test/java/com/rits/tests/cloning/TestCloner.java
@@ -42,12 +42,22 @@ public class TestCloner extends TestCase {
     static private class MyAX {
     }
 
-    public void testCloneListOf12(){
-        Assert.assertEquals(1, cloner.deepClone(List.of(1)).size());
+    public void testCloneListOf12() {
+        List list1 = List.of(1);
+        Assert.assertEquals(list1, cloner.deepClone(list1));
+        Assert.assertEquals(1, cloner.deepClone(list1).size());
+        List list2 = List.of(1, 2);
+        Assert.assertEquals(list2, cloner.deepClone(list2));
+        Assert.assertEquals(2, cloner.deepClone(list2).size());
     }
 
-    public void testCloneSetOf12(){
-        Assert.assertEquals(1, cloner.deepClone(Set.of(1)).size());
+    public void testCloneSetOf12() {
+        Set set1 = Set.of(1);
+        Assert.assertEquals(set1, cloner.deepClone(set1));
+        Assert.assertEquals(1, cloner.deepClone(set1).size());
+        Set set2 = Set.of(1, 2);
+        Assert.assertEquals(set2, cloner.deepClone(set2));
+        Assert.assertEquals(2, cloner.deepClone(set2).size());
     }
 
     public void testCalendarTimezone() {


### PR DESCRIPTION
To fix issue [#103 ](https://github.com/kostaskougios/cloning/issues/103)
In jdk 5, `cloner.deepClone(Set.of(1)).size()` will be 2 because `EMPTY`( it is `null` in jdk14 ) will be changed with clone. So it has to create new FastCloner.